### PR TITLE
Add minimal Android atom game prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Gradle files
+.gradle/
+build/
+app/build/
+local.properties
+
+# Android Studio
+.idea/
+.DS_Store
+
+# Others

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Nucleus
+
+This repository contains a minimal Android game prototype written in Kotlin using Jetpack Compose. The game presents an atom-like player that can move around the screen and collect free electrons. Each time an electron is collected, the player's "power" increases. This is just a starting point for a more complete game.
+
+## Building
+
+To build the project, you need Android Studio or the Android command-line tools. After installing the required SDK packages, run:
+
+```bash
+./gradlew assembleDebug
+```
+
+This will compile the application. You can then install the generated APK on an emulator or device.
+

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.nucleus'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.nucleus'
+        minSdk 21
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion '1.5.4'
+    }
+
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation "androidx.core:core-ktx:1.12.0"
+    implementation "androidx.lifecycle:lifecycle-runtime-ktx:2.6.2"
+    implementation "androidx.activity:activity-compose:1.8.2"
+    implementation "androidx.compose.ui:ui:1.5.4"
+    implementation "androidx.compose.material3:material3:1.2.0"
+    implementation "androidx.compose.ui:ui-tooling-preview:1.5.4"
+    debugImplementation "androidx.compose.ui:ui-tooling:1.5.4"
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.nucleus">
+
+    <application
+        android:allowBackup="true"
+        android:label="Nucleus"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.App">
+        <activity android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/app/src/main/java/com/example/nucleus/GameView.kt
+++ b/app/src/main/java/com/example/nucleus/GameView.kt
@@ -1,0 +1,76 @@
+package com.example.nucleus
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import kotlinx.coroutines.delay
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+
+private const val PLAYER_RADIUS = 40f
+private const val ELECTRON_RADIUS = 10f
+
+@Composable
+fun GameScreen() {
+    val player = remember { Particle(Offset(300f, 300f), PLAYER_RADIUS) }
+    val electrons = remember { mutableStateListOf<Particle>() }
+    var power by remember { mutableStateOf(0) }
+
+    LaunchedEffect(Unit) {
+        repeat(20) {
+            electrons += Particle(randomOffset(), ELECTRON_RADIUS)
+        }
+        while (true) {
+            delay(16)
+            electrons.forEach { it.moveRandom() }
+            electrons.removeAll { electron ->
+                if (player.overlaps(electron)) {
+                    power += 1
+                    true
+                } else false
+            }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black)
+            .pointerInput(Unit) {
+                detectDragGestures { change, _ ->
+                    player.position = change.position
+                }
+            }
+    ) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            drawCircle(Color.Cyan, player.radius, player.position)
+            electrons.forEach { drawCircle(Color.Yellow, it.radius, it.position) }
+        }
+    }
+}
+
+private fun randomOffset(): Offset = Offset(Random.nextFloat() * 600f, Random.nextFloat() * 800f)
+
+private data class Particle(var position: Offset, val radius: Float) {
+    fun moveRandom() {
+        position += Offset(Random.nextFloat() * 4 - 2, Random.nextFloat() * 4 - 2)
+    }
+
+    fun overlaps(other: Particle): Boolean {
+        val dx = position.x - other.position.x
+        val dy = position.y - other.position.y
+        val distSq = dx*dx + dy*dy
+        val r = radius + other.radius
+        return distSq < r*r
+    }
+}

--- a/app/src/main/java/com/example/nucleus/MainActivity.kt
+++ b/app/src/main/java/com/example/nucleus/MainActivity.kt
@@ -1,0 +1,30 @@
+package com.example.nucleus
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                Surface {
+                    GameScreen()
+                }
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun DefaultPreview() {
+    MaterialTheme {
+        GameScreen()
+    }
+}

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.App" parent="Theme.Material3.DayNight.NoActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,21 @@
+buildscript {
+    ext {
+        compose_ui_version = '1.5.4'
+        kotlin_version = '1.9.10'
+    }
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.2.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = "Nucleus"
+include(":app")


### PR DESCRIPTION
## Summary
- introduce a simple Jetpack Compose game where a player atom collects electrons
- provide gradle configuration and Android manifest
- add minimal theme and README instructions

## Testing
- `gradle build` *(fails: Could not resolve dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684deb34d844832ebb761552f4155bfa